### PR TITLE
release: 2.1.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0-rc2] - 2025-11-30
+
+### Changed
+
+- Add a `rust-toolchain.toml` to try to fix `dist` for `aarch64-pc-windows-msvc`. See commit message for verbose details.
+
 ## [2.1.0-rc1] - 2025-11-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "compile-typst-site"
-version = "2.1.0-rc1"
+version = "2.1.0-rc2"
 dependencies = [
  "anyhow",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "compile-typst-site"
 description = "Command-line program for static site generation using Typst."
 repository = "https://github.com/wade-cheng/compile-typst-site/"
-version = "2.1.0-rc1"
+version = "2.1.0-rc2"
 edition = "2024"
 license = "MIT"
 exclude = [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
I'm using `dist` to generate a CI yml to generate binaries for my CLI. I'm getting the compilation error `error[E0658]: let expressions in this position are unstable` in release CI for _only_ aarch64-pc-windows-msvc. The error mentions https://github.com/rust-lang/rust/issues/53667, which leads me to believe it is supplying an outdated rust somehow? I have

```
       "artifacts": [

        "source.tar.gz",

        "source.tar.gz.sha256",

        "compile-typst-site-installer.sh",

        "compile-typst-site-installer.ps1",

        "sha256.sum",

        "compile-typst-site-aarch64-apple-darwin.tar.xz",

        "compile-typst-site-aarch64-apple-darwin.tar.xz.sha256",

        "compile-typst-site-aarch64-pc-windows-msvc.zip",

        "compile-typst-site-aarch64-pc-windows-msvc.zip.sha256",

        "compile-typst-site-aarch64-unknown-linux-gnu.tar.xz",

        "compile-typst-site-aarch64-unknown-linux-gnu.tar.xz.sha256",

        "compile-typst-site-x86_64-apple-darwin.tar.xz",

        "compile-typst-site-x86_64-apple-darwin.tar.xz.sha256",

        "compile-typst-site-x86_64-pc-windows-msvc.zip",

        "compile-typst-site-x86_64-pc-windows-msvc.zip.sha256",

        "compile-typst-site-x86_64-unknown-linux-gnu.tar.xz",

        "compile-typst-site-x86_64-unknown-linux-gnu.tar.xz.sha256",

        "compile-typst-site-x86_64-unknown-linux-musl.tar.xz",

        "compile-typst-site-x86_64-unknown-linux-musl.tar.xz.sha256"

      ],
```

A maintainer suggested "Also I think just using a rust-toolchain.toml is the fix for this problem:" https://github.com/axodotdev/cargo-dist/pull/2192